### PR TITLE
feat: Implement parsers for uint64 and []uint64

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Package getenv provides functionality for loading environment variables and pars
 - []int
 - int64
 - []int64
+- uint64
+- []uint64
 - float64
 - []float64
 - time.Time

--- a/getenv.go
+++ b/getenv.go
@@ -2,8 +2,6 @@
 package getenv
 
 import (
-	"time"
-
 	"github.com/obalunenko/getenv/internal"
 	"github.com/obalunenko/getenv/option"
 )
@@ -29,103 +27,4 @@ func newParseParams(opts []option.Option) internal.Parameters {
 	}
 
 	return p
-}
-
-// IntOrDefault retrieves the int value of the environment variable named
-// by the key.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func IntOrDefault(key string, defaultVal int) int {
-	return EnvOrDefault(key, defaultVal)
-}
-
-// StringOrDefault retrieves the string value of the environment variable named
-// by the key.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func StringOrDefault(key, defaultVal string) string {
-	return EnvOrDefault(key, defaultVal)
-}
-
-// BoolOrDefault retrieves the bool value of the environment variable named
-// by the key.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func BoolOrDefault(key string, defaultVal bool) bool {
-	return EnvOrDefault(key, defaultVal)
-}
-
-// StringSliceOrDefault retrieves the string slice value of the environment variable named
-// by the key and separated by sep.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func StringSliceOrDefault(key string, defaultVal []string, sep string) []string {
-	return EnvOrDefault(key, defaultVal, option.WithSeparator(sep))
-}
-
-// IntSliceOrDefault retrieves the int slice value of the environment variable named
-// by the key and separated by sep.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func IntSliceOrDefault(key string, defaultVal []int, sep string) []int {
-	return EnvOrDefault(key, defaultVal, option.WithSeparator(sep))
-}
-
-// Float64SliceOrDefault retrieves the float64 slice value of the environment variable named
-// by the key and separated by sep.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func Float64SliceOrDefault(key string, defaultVal []float64, sep string) []float64 {
-	return EnvOrDefault(key, defaultVal, option.WithSeparator(sep))
-}
-
-// DurationOrDefault retrieves the time.Duration value of the environment variable named
-// by the key.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func DurationOrDefault(key string, defaultVal time.Duration) time.Duration {
-	return EnvOrDefault(key, defaultVal)
-}
-
-// TimeOrDefault retrieves the time.Time value of the environment variable named
-// by the key represented by layout.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func TimeOrDefault(key string, defaultVal time.Time, layout string) time.Time {
-	return EnvOrDefault(key, defaultVal, option.WithTimeLayout(layout))
-}
-
-// Int64OrDefault retrieves the int64 value of the environment variable named
-// by the key.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func Int64OrDefault(key string, defaultVal int64) int64 {
-	return EnvOrDefault(key, defaultVal)
-}
-
-// Float64OrDefault retrieves the float64 value of the environment variable named
-// by the key.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func Float64OrDefault(key string, defaultVal float64) float64 {
-	return EnvOrDefault(key, defaultVal)
-}
-
-// Int64SliceOrDefault retrieves the int6464 slice value of the environment variable named
-// by the key and separated by sep.
-// If variable not set or value is empty - defaultVal will be returned.
-//
-// Deprecated: use EnvOrDefault.
-func Int64SliceOrDefault(key string, defaultVal []int64, sep string) []int64 {
-	return EnvOrDefault(key, defaultVal, option.WithSeparator(sep))
 }

--- a/getenv_test.go
+++ b/getenv_test.go
@@ -1010,8 +1010,194 @@ func TestDurationOrDefault(t *testing.T) {
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal)
 			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
 
-			got = getenv.DurationOrDefault(tt.args.key, tt.args.defaultVal)
+func TestUint64OrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal uint64
+	}
+
+	type expected struct {
+		val uint64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "12",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 999,
+			},
+			expected: expected{
+				val: 999,
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 999,
+			},
+			expected: expected{
+				val: 12,
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 999,
+			},
+			expected: expected{
+				val: 999,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func TestUint64SliceOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal []uint64
+		sep        string
+	}
+
+	type expected struct {
+		val []uint64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "1,27",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []uint64{1, 2},
+			},
+		},
+		{
+			name: "env set, no separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        "",
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+		{
+			name: "env set, wrong separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        "|",
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal, option.WithSeparator(tt.args.sep))
 			assert.Equal(t, tt.expected.val, got)
 		})
 	}

--- a/getenv_test.go
+++ b/getenv_test.go
@@ -99,9 +99,6 @@ func TestIntOrDefault(t *testing.T) {
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal)
 			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.IntOrDefault(tt.args.key, tt.args.defaultVal)
-			assert.Equal(t, tt.expected.val, got)
 		})
 	}
 }
@@ -161,9 +158,6 @@ func TestStringOrDefault(t *testing.T) {
 			tt.precond.maybeSetEnv(t, tt.args.key)
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal)
-			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.StringOrDefault(tt.args.key, tt.args.defaultVal)
 			assert.Equal(t, tt.expected.val, got)
 		})
 	}
@@ -241,9 +235,6 @@ func TestInt64OrDefault(t *testing.T) {
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal)
 			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.Int64OrDefault(tt.args.key, tt.args.defaultVal)
-			assert.Equal(t, tt.expected.val, got)
 		})
 	}
 }
@@ -320,9 +311,6 @@ func TestFloat64OrDefault(t *testing.T) {
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal)
 			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.Float64OrDefault(tt.args.key, tt.args.defaultVal)
-			assert.Equal(t, tt.expected.val, got)
 		})
 	}
 }
@@ -398,9 +386,6 @@ func TestBoolOrDefault(t *testing.T) {
 			tt.precond.maybeSetEnv(t, tt.args.key)
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal)
-			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.BoolOrDefault(tt.args.key, tt.args.defaultVal)
 			assert.Equal(t, tt.expected.val, got)
 		})
 	}
@@ -497,9 +482,6 @@ func TestStringSliceOrDefault(t *testing.T) {
 			tt.precond.maybeSetEnv(t, tt.args.key)
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal, option.WithSeparator(tt.args.sep))
-			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.StringSliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
 			assert.Equal(t, tt.expected.val, got)
 		})
 	}
@@ -614,9 +596,6 @@ func TestIntSliceOrDefault(t *testing.T) {
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal, option.WithSeparator(tt.args.sep))
 			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.IntSliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
-			assert.Equal(t, tt.expected.val, got)
 		})
 	}
 }
@@ -729,9 +708,6 @@ func TestFloat64SliceOrDefault(t *testing.T) {
 			tt.precond.maybeSetEnv(t, tt.args.key)
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal, option.WithSeparator(tt.args.sep))
-			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.Float64SliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
 			assert.Equal(t, tt.expected.val, got)
 		})
 	}
@@ -846,9 +822,6 @@ func TestInt64SliceOrDefault(t *testing.T) {
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal, option.WithSeparator(tt.args.sep))
 			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.Int64SliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
-			assert.Equal(t, tt.expected.val, got)
 		})
 	}
 }
@@ -930,9 +903,6 @@ func TestTimeOrDefault(t *testing.T) {
 			tt.precond.maybeSetEnv(t, tt.args.key)
 
 			got := getenv.EnvOrDefault(tt.args.key, tt.args.defaultVal, option.WithTimeLayout(tt.args.layout))
-			assert.Equal(t, tt.expected.val, got)
-
-			got = getenv.TimeOrDefault(tt.args.key, tt.args.defaultVal, tt.args.layout)
 			assert.Equal(t, tt.expected.val, got)
 		})
 	}

--- a/getenv_test.go
+++ b/getenv_test.go
@@ -27,6 +27,24 @@ func (p precond) maybeSetEnv(tb testing.TB, key string) {
 	}
 }
 
+func BenchmarkEnvOrDefault(b *testing.B) {
+	p := precond{
+		setenv: setenv{
+			isSet: true,
+			val:   "1235.67,87.98",
+		},
+	}
+
+	p.maybeSetEnv(b, testEnvKey)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = getenv.EnvOrDefault(testEnvKey, []float64{}, option.WithSeparator(","))
+	}
+}
+
 func TestIntOrDefault(t *testing.T) {
 	type args struct {
 		key        string

--- a/getenv_test.go
+++ b/getenv_test.go
@@ -17,18 +17,18 @@ type setenv struct {
 	val   string
 }
 
-type precond struct {
+type precondition struct {
 	setenv setenv
 }
 
-func (p precond) maybeSetEnv(tb testing.TB, key string) {
+func (p precondition) maybeSetEnv(tb testing.TB, key string) {
 	if p.setenv.isSet {
 		tb.Setenv(key, p.setenv.val)
 	}
 }
 
 func BenchmarkEnvOrDefault(b *testing.B) {
-	p := precond{
+	p := precondition{
 		setenv: setenv{
 			isSet: true,
 			val:   "1235.67,87.98",
@@ -57,13 +57,13 @@ func TestIntOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "128",
@@ -79,7 +79,7 @@ func TestIntOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128",
@@ -95,7 +95,7 @@ func TestIntOrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -133,13 +133,13 @@ func TestStringOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "newval",
@@ -155,7 +155,7 @@ func TestStringOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "newval",
@@ -193,13 +193,13 @@ func TestInt64OrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "newval",
@@ -215,7 +215,7 @@ func TestInt64OrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1024",
@@ -231,7 +231,7 @@ func TestInt64OrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -269,13 +269,13 @@ func TestFloat64OrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "newval",
@@ -291,7 +291,7 @@ func TestFloat64OrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1024.123",
@@ -307,7 +307,7 @@ func TestFloat64OrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -345,13 +345,13 @@ func TestBoolOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "true",
@@ -367,7 +367,7 @@ func TestBoolOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "true",
@@ -383,7 +383,7 @@ func TestBoolOrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -422,13 +422,13 @@ func TestStringSliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "true,newval",
@@ -445,7 +445,7 @@ func TestStringSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "true,newval",
@@ -462,7 +462,7 @@ func TestStringSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "true,newval",
@@ -479,7 +479,7 @@ func TestStringSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -518,13 +518,13 @@ func TestIntSliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1,2",
@@ -541,7 +541,7 @@ func TestIntSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -558,7 +558,7 @@ func TestIntSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -575,7 +575,7 @@ func TestIntSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -592,7 +592,7 @@ func TestIntSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -631,13 +631,13 @@ func TestFloat64SliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1.05,2.07",
@@ -654,7 +654,7 @@ func TestFloat64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1.05,2.07",
@@ -671,7 +671,7 @@ func TestFloat64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1.05,2.07",
@@ -688,7 +688,7 @@ func TestFloat64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1.05,2.07",
@@ -705,7 +705,7 @@ func TestFloat64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -744,13 +744,13 @@ func TestInt64SliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1.05,2.07",
@@ -767,7 +767,7 @@ func TestInt64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -784,7 +784,7 @@ func TestInt64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -801,7 +801,7 @@ func TestInt64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -818,7 +818,7 @@ func TestInt64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -859,13 +859,13 @@ func TestTimeOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "2018/21/04 22:30",
@@ -882,7 +882,7 @@ func TestTimeOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "2018/21/04 22:30",
@@ -899,7 +899,7 @@ func TestTimeOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -938,13 +938,13 @@ func TestDurationOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "12s",
@@ -960,7 +960,7 @@ func TestDurationOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12s",
@@ -976,7 +976,7 @@ func TestDurationOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -1014,13 +1014,13 @@ func TestUint64OrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "12",
@@ -1036,7 +1036,7 @@ func TestUint64OrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12",
@@ -1052,7 +1052,7 @@ func TestUint64OrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -1091,13 +1091,13 @@ func TestUint64SliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1,27",
@@ -1114,7 +1114,7 @@ func TestUint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -1131,7 +1131,7 @@ func TestUint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -1148,7 +1148,7 @@ func TestUint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -1165,7 +1165,7 @@ func TestUint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -1,0 +1,26 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type panicAssertionFunc func(t assert.TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) bool
+
+const testEnvKey = "GH_GETENV_TEST"
+
+type setenv struct {
+	isSet bool
+	val   string
+}
+
+type precond struct {
+	setenv setenv
+}
+
+func (p precond) maybeSetEnv(tb testing.TB, key string) {
+	if p.setenv.isSet {
+		tb.Setenv(key, p.setenv.val)
+	}
+}

--- a/internal/common_test.go
+++ b/internal/common_test.go
@@ -15,11 +15,11 @@ type setenv struct {
 	val   string
 }
 
-type precond struct {
+type precondition struct {
 	setenv setenv
 }
 
-func (p precond) maybeSetEnv(tb testing.TB, key string) {
+func (p precondition) maybeSetEnv(tb testing.TB, key string) {
 	if p.setenv.isSet {
 		tb.Setenv(key, p.setenv.val)
 	}

--- a/internal/constraint.go
+++ b/internal/constraint.go
@@ -16,7 +16,7 @@ type String interface {
 
 // Int is a constraint for integer and slice of integers.
 type Int interface {
-	int | []int | int64 | []int64
+	int | []int | int64 | []int64 | uint64 | []uint64
 }
 
 // Float is a constraint for floats and slice of floats.

--- a/internal/iface.go
+++ b/internal/iface.go
@@ -29,6 +29,10 @@ func NewEnvParser(v any) EnvParser {
 		p = float64Parser(v.(float64))
 	case []float64:
 		p = float64SliceParser(v.([]float64))
+	case uint64:
+		p = uint64Parser(v.(uint64))
+	case []uint64:
+		p = uint64SliceParser(v.([]uint64))
 	case time.Time:
 		p = timeParser(v.(time.Time))
 	case time.Duration:
@@ -145,6 +149,24 @@ type durationParser time.Duration
 
 func (d durationParser) ParseEnv(key string, defaltVal any, _ Parameters) any {
 	val := durationOrDefault(key, defaltVal.(time.Duration))
+
+	return val
+}
+
+type uint64Parser uint64
+
+func (d uint64Parser) ParseEnv(key string, defaltVal any, _ Parameters) any {
+	val := uint64OrDefault(key, defaltVal.(uint64))
+
+	return val
+}
+
+type uint64SliceParser []uint64
+
+func (i uint64SliceParser) ParseEnv(key string, defaltVal any, options Parameters) any {
+	sep := options.Separator
+
+	val := uint64SliceOrDefault(key, defaltVal.([]uint64), sep)
 
 	return val
 }

--- a/internal/iface.go
+++ b/internal/iface.go
@@ -41,18 +41,12 @@ func NewEnvParser(v any) EnvParser {
 		panic(fmt.Sprintf("unsupported type :%T", i))
 	}
 
-	return envParserWrap{
-		EnvParser: p,
-	}
+	return p
 }
 
 // EnvParser interface for parsing environment variables.
 type EnvParser interface {
 	ParseEnv(key string, defaltVal any, options Parameters) any
-}
-
-type envParserWrap struct {
-	EnvParser
 }
 
 type stringParser string

--- a/internal/iface.go
+++ b/internal/iface.go
@@ -24,7 +24,7 @@ func NewEnvParser(v any) EnvParser {
 	case int64:
 		p = int64Parser(v.(int64))
 	case []int64:
-		p = in64SliceParser(v.([]int64))
+		p = int64SliceParser(v.([]int64))
 	case float64:
 		p = float64Parser(v.(float64))
 	case []float64:
@@ -103,9 +103,9 @@ func (i int64Parser) ParseEnv(key string, defaltVal any, _ Parameters) any {
 	return val
 }
 
-type in64SliceParser []int64
+type int64SliceParser []int64
 
-func (i in64SliceParser) ParseEnv(key string, defaltVal any, options Parameters) any {
+func (i int64SliceParser) ParseEnv(key string, defaltVal any, options Parameters) any {
 	sep := options.Separator
 
 	val := int64SliceOrDefault(key, defaltVal.([]int64), sep)

--- a/internal/iface_test.go
+++ b/internal/iface_test.go
@@ -1,0 +1,411 @@
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEnvParser(t *testing.T) {
+	type args struct {
+		v any
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		want      EnvParser
+		wantPanic panicAssertionFunc
+	}{
+		{
+			name: "int64",
+			args: args{
+				v: int64(1),
+			},
+			want:      int64Parser(1),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "[]int64",
+			args: args{
+				v: []int64{1},
+			},
+			want:      int64SliceParser([]int64{1}),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "uint64",
+			args: args{
+				v: uint64(1),
+			},
+			want:      uint64Parser(1),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "[]uint64",
+			args: args{
+				v: []uint64{1},
+			},
+			want:      uint64SliceParser([]uint64{1}),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "int",
+			args: args{
+				v: 1,
+			},
+			want:      intParser(1),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "[]int",
+			args: args{
+				v: []int{1},
+			},
+			want:      intSliceParser([]int{1}),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "string",
+			args: args{
+				v: "s",
+			},
+			want:      stringParser("s"),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "[]string",
+			args: args{
+				v: []string{"s"},
+			},
+			want:      stringSliceParser([]string{"s"}),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "bool",
+			args: args{
+				v: true,
+			},
+			want:      boolParser(true),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "float64",
+			args: args{
+				v: 1.1,
+			},
+			want:      float64Parser(1.1),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "[]float64",
+			args: args{
+				v: []float64{1.1},
+			},
+			want:      float64SliceParser([]float64{1.1}),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "time.Time",
+			args: args{
+				v: time.Time{},
+			},
+			want:      timeParser(time.Time{}),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "time.Duration",
+			args: args{
+				v: time.Minute,
+			},
+			want:      durationParser(time.Minute),
+			wantPanic: assert.NotPanics,
+		},
+		{
+			name: "not supported - panics",
+			args: args{
+				v: byte(1),
+			},
+			want:      nil,
+			wantPanic: assert.Panics,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got EnvParser
+
+			if !tt.wantPanic(t, func() {
+				got = NewEnvParser(tt.args.v)
+			}) {
+				return
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_ParseEnv(t *testing.T) {
+	type args struct {
+		key       string
+		defaltVal any
+		in2       Parameters
+	}
+
+	tests := []struct {
+		name    string
+		precond precond
+		s       EnvParser
+		args    args
+		want    any
+	}{
+		{
+			name: "boolParser",
+			s:    boolParser(true),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "true",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: false,
+				in2:       Parameters{},
+			},
+			want: true,
+		},
+		{
+			name: "stringParser",
+			s:    stringParser(""),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "golly",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: "test",
+				in2:       Parameters{},
+			},
+			want: "golly",
+		},
+		{
+			name: "stringSliceParser",
+			s:    stringSliceParser(nil),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "golly,sally",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: []string{},
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: []string{"golly", "sally"},
+		},
+		{
+			name: "float64Parser",
+			s:    float64Parser(0),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "-1.2",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: float64(99),
+				in2:       Parameters{},
+			},
+			want: -1.2,
+		},
+		{
+			name: "float64Parser",
+			s:    float64SliceParser(nil),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "-1.2,0.2",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: []float64{99},
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: []float64{-1.2, 0.2},
+		},
+		{
+			name: "uint64Parser",
+			s:    uint64Parser(0),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: uint64(99),
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: uint64(12),
+		},
+		{
+			name: "uint64SliceParser",
+			s:    uint64SliceParser(nil),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12,89",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: []uint64{99},
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: []uint64{12, 89},
+		},
+		{
+			name: "int64Parser",
+			s:    int64Parser(0),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: int64(99),
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: int64(12),
+		},
+		{
+			name: "int64SliceParser",
+			s:    int64SliceParser(nil),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12,89",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: []int64{99},
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: []int64{12, 89},
+		},
+		{
+			name: "intParser",
+			s:    intParser(0),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: 99,
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: 12,
+		},
+		{
+			name: "intSliceParser",
+			s:    intSliceParser(nil),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12,89",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: []int{99},
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: []int{12, 89},
+		},
+		{
+			name: "durationParser",
+			s:    durationParser(0),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12s",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: time.Duration(0),
+				in2: Parameters{
+					Separator: ",",
+					Layout:    "",
+				},
+			},
+			want: time.Second * 12,
+		},
+		{
+			name: "timeParser",
+			s:    timeParser(time.Time{}),
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "2022-03-24",
+				},
+			},
+			args: args{
+				key:       testEnvKey,
+				defaltVal: time.Time{},
+				in2: Parameters{
+					Separator: "",
+					Layout:    time.DateOnly,
+				},
+			},
+			want: time.Date(2022, time.March, 24, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, testEnvKey)
+
+			assert.Equalf(t, tt.want, tt.s.ParseEnv(tt.args.key, tt.args.defaltVal, tt.args.in2), "ParseEnv(%v, %v, %v)", tt.args.key, tt.args.defaltVal, tt.args.in2)
+		})
+	}
+}

--- a/internal/iface_test.go
+++ b/internal/iface_test.go
@@ -156,7 +156,7 @@ func Test_ParseEnv(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		precond precond
+		precond precondition
 		s       EnvParser
 		args    args
 		want    any
@@ -164,7 +164,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "boolParser",
 			s:    boolParser(true),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "true",
@@ -180,7 +180,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "stringParser",
 			s:    stringParser(""),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "golly",
@@ -196,7 +196,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "stringSliceParser",
 			s:    stringSliceParser(nil),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "golly,sally",
@@ -215,7 +215,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "float64Parser",
 			s:    float64Parser(0),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "-1.2",
@@ -231,7 +231,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "float64Parser",
 			s:    float64SliceParser(nil),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "-1.2,0.2",
@@ -250,7 +250,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "uint64Parser",
 			s:    uint64Parser(0),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12",
@@ -269,7 +269,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "uint64SliceParser",
 			s:    uint64SliceParser(nil),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12,89",
@@ -288,7 +288,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "int64Parser",
 			s:    int64Parser(0),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12",
@@ -307,7 +307,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "int64SliceParser",
 			s:    int64SliceParser(nil),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12,89",
@@ -326,7 +326,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "intParser",
 			s:    intParser(0),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12",
@@ -345,7 +345,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "intSliceParser",
 			s:    intSliceParser(nil),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12,89",
@@ -364,7 +364,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "durationParser",
 			s:    durationParser(0),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12s",
@@ -383,7 +383,7 @@ func Test_ParseEnv(t *testing.T) {
 		{
 			name: "timeParser",
 			s:    timeParser(time.Time{}),
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "2022-03-24",
@@ -405,7 +405,7 @@ func Test_ParseEnv(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.precond.maybeSetEnv(t, testEnvKey)
 
-			assert.Equalf(t, tt.want, tt.s.ParseEnv(tt.args.key, tt.args.defaltVal, tt.args.in2), "ParseEnv(%v, %v, %v)", tt.args.key, tt.args.defaltVal, tt.args.in2)
+			assert.Equal(t, tt.want, tt.s.ParseEnv(tt.args.key, tt.args.defaltVal, tt.args.in2))
 		})
 	}
 }

--- a/internal/parsers.go
+++ b/internal/parsers.go
@@ -225,3 +225,53 @@ func float64OrDefault(key string, defaultVal float64) float64 {
 
 	return val
 }
+
+// uint64OrDefault retrieves the unt64 value of the environment variable named
+// by the key.
+// If variable not set or value is empty - defaultVal will be returned.
+func uint64OrDefault(key string, defaultVal uint64) uint64 {
+	env := stringOrDefault(key, "")
+	if env == "" {
+		return defaultVal
+	}
+
+	const (
+		base    = 10
+		bitsize = 64
+	)
+
+	val, err := strconv.ParseUint(env, base, bitsize)
+	if err != nil {
+		return defaultVal
+	}
+
+	return val
+}
+
+// uint64SliceOrDefault retrieves the uint64 slice value of the environment variable named
+// by the key and separated by sep.
+// If variable not set or value is empty - defaultVal will be returned.
+func uint64SliceOrDefault(key string, defaultVal []uint64, sep string) []uint64 {
+	valraw := stringSliceOrDefault(key, nil, sep)
+	if valraw == nil {
+		return defaultVal
+	}
+
+	val := make([]uint64, 0, len(valraw))
+
+	const (
+		base    = 10
+		bitsize = 64
+	)
+
+	for _, s := range valraw {
+		v, err := strconv.ParseUint(s, base, bitsize)
+		if err != nil {
+			return defaultVal
+		}
+
+		val = append(val, v)
+	}
+
+	return val
+}

--- a/internal/parsers_test.go
+++ b/internal/parsers_test.go
@@ -24,6 +24,24 @@ func (p precond) maybeSetEnv(tb testing.TB, key string) {
 	}
 }
 
+func Benchmark_float64SliceOrDefault(b *testing.B) {
+	p := precond{
+		setenv: setenv{
+			isSet: true,
+			val:   "1235.67,87.98",
+		},
+	}
+
+	p.maybeSetEnv(b, testEnvKey)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = float64SliceOrDefault(testEnvKey, []float64{}, ",")
+	}
+}
+
 func TestNewEnvParser(t *testing.T) {
 	type args struct {
 		v any

--- a/internal/parsers_test.go
+++ b/internal/parsers_test.go
@@ -46,6 +46,7 @@ func TestNewEnvParser(t *testing.T) {
 	type args struct {
 		v any
 	}
+	
 	tests := []struct {
 		name string
 		args args
@@ -59,6 +60,7 @@ func TestNewEnvParser(t *testing.T) {
 			want: int64Parser(0),
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewEnvParser(tt.args.v)

--- a/internal/parsers_test.go
+++ b/internal/parsers_test.go
@@ -1,0 +1,1196 @@
+package internal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testEnvKey = "GH_GETENV_TEST"
+
+type setenv struct {
+	isSet bool
+	val   string
+}
+
+type precond struct {
+	setenv setenv
+}
+
+func (p precond) maybeSetEnv(tb testing.TB, key string) {
+	if p.setenv.isSet {
+		tb.Setenv(key, p.setenv.val)
+	}
+}
+
+func TestNewEnvParser(t *testing.T) {
+	type args struct {
+		v any
+	}
+	tests := []struct {
+		name string
+		args args
+		want EnvParser
+	}{
+		{
+			name: "",
+			args: args{
+				v: int64(0),
+			},
+			want: int64Parser(0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewEnvParser(tt.args.v)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_intOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal int
+	}
+
+	type expected struct {
+		val int
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "128",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 42,
+			},
+			expected: expected{
+				val: 42,
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "128",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 44,
+			},
+			expected: expected{
+				val: 128,
+			},
+		},
+		{
+			name: "invalid env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "128s7",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 44,
+			},
+			expected: expected{
+				val: 44,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := intOrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_stringOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal string
+	}
+
+	type expected struct {
+		val string
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "newval",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: "default",
+			},
+			expected: expected{
+				val: "default",
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "newval",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: "default",
+			},
+			expected: expected{
+				val: "newval",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := stringOrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_int64OrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal int64
+	}
+
+	type expected struct {
+		val int64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "newval",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 956,
+			},
+			expected: expected{
+				val: 956,
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1024",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 42,
+			},
+			expected: expected{
+				val: 1024,
+			},
+		},
+		{
+			name: "invalid env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "128s7",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 44,
+			},
+			expected: expected{
+				val: 44,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := int64OrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_float64OrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal float64
+	}
+
+	type expected struct {
+		val float64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "newval",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 956.02,
+			},
+			expected: expected{
+				val: 956.02,
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1024.123",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 42,
+			},
+			expected: expected{
+				val: 1024.123,
+			},
+		},
+		{
+			name: "invalid env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "128s7",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 44,
+			},
+			expected: expected{
+				val: 44,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := float64OrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_boolOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal bool
+	}
+
+	type expected struct {
+		val bool
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "true",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: false,
+			},
+			expected: expected{
+				val: false,
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "true",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: false,
+			},
+			expected: expected{
+				val: true,
+			},
+		},
+		{
+			name: "invalid env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "128s7",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: true,
+			},
+			expected: expected{
+				val: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := boolOrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_stringSliceOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal []string
+		sep        string
+	}
+
+	type expected struct {
+		val []string
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "true,newval",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []string{"no values"},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []string{"no values"},
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "true,newval",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []string{"no values"},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []string{"true", "newval"},
+			},
+		},
+		{
+			name: "env set, no separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "true,newval",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []string{"no values"},
+				sep:        "",
+			},
+			expected: expected{
+				val: []string{"no values"},
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []string{"no values"},
+			},
+			expected: expected{
+				val: []string{"no values"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := stringSliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_intSliceOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal []int
+		sep        string
+	}
+
+	type expected struct {
+		val []int
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int{-99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []int{-99},
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int{-99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []int{1, 2},
+			},
+		},
+		{
+			name: "env set, no separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int{-99},
+				sep:        "",
+			},
+			expected: expected{
+				val: []int{-99},
+			},
+		},
+		{
+			name: "env set, wrong separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int{-99},
+				sep:        "|",
+			},
+			expected: expected{
+				val: []int{-99},
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int{-99},
+			},
+			expected: expected{
+				val: []int{-99},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := intSliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_float64SliceOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal []float64
+		sep        string
+	}
+
+	type expected struct {
+		val []float64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "1.05,2.07",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []float64{-99.99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []float64{-99.99},
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1.05,2.07",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []float64{-99.99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []float64{1.05, 2.07},
+			},
+		},
+		{
+			name: "env set, no separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1.05,2.07",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []float64{-99.99},
+				sep:        "",
+			},
+			expected: expected{
+				val: []float64{-99.99},
+			},
+		},
+		{
+			name: "env set, wrong separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1.05,2.07",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []float64{-99.99},
+				sep:        "|",
+			},
+			expected: expected{
+				val: []float64{-99.99},
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []float64{-99.99},
+			},
+			expected: expected{
+				val: []float64{-99.99},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := float64SliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_int64SliceOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal []int64
+		sep        string
+	}
+
+	type expected struct {
+		val []int64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "1.05,2.07",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int64{-99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []int64{-99},
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int64{-99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []int64{1, 2},
+			},
+		},
+		{
+			name: "env set, no separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int64{-99},
+				sep:        "",
+			},
+			expected: expected{
+				val: []int64{-99},
+			},
+		},
+		{
+			name: "env set, wrong separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int64{-99},
+				sep:        "|",
+			},
+			expected: expected{
+				val: []int64{-99},
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int64{-99},
+			},
+			expected: expected{
+				val: []int64{-99},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := int64SliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_timeOrDefault(t *testing.T) {
+	const layout = "2006/02/01 15:04"
+
+	type args struct {
+		key        string
+		defaultVal time.Time
+		layout     string
+	}
+
+	type expected struct {
+		val time.Time
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "2018/21/04 22:30",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Date(2021, 04, 21, 22, 30, 0, 0, time.UTC),
+				layout:     layout,
+			},
+			expected: expected{
+				val: time.Date(2021, 04, 21, 22, 30, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "2018/21/04 22:30",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Date(2021, 04, 21, 22, 30, 0, 0, time.UTC),
+				layout:     layout,
+			},
+			expected: expected{
+				val: time.Date(2018, 04, 21, 22, 30, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Date(2021, 04, 21, 22, 30, 0, 0, time.UTC),
+				layout:     layout,
+			},
+			expected: expected{
+				val: time.Date(2021, 04, 21, 22, 30, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := timeOrDefault(tt.args.key, tt.args.defaultVal, tt.args.layout)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_durationOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal time.Duration
+	}
+
+	type expected struct {
+		val time.Duration
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "12s",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Second * 42,
+			},
+			expected: expected{
+				val: time.Second * 42,
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12s",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Second * 42,
+			},
+			expected: expected{
+				val: time.Second * 12,
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Second * 42,
+			},
+			expected: expected{
+				val: time.Second * 42,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := durationOrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_uint64OrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal uint64
+	}
+
+	type expected struct {
+		val uint64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "12",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 999,
+			},
+			expected: expected{
+				val: 999,
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "12",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 999,
+			},
+			expected: expected{
+				val: 12,
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 999,
+			},
+			expected: expected{
+				val: 999,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := uint64OrDefault(tt.args.key, tt.args.defaultVal)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}
+
+func Test_uint64SliceOrDefault(t *testing.T) {
+	type args struct {
+		key        string
+		defaultVal []uint64
+		sep        string
+	}
+
+	type expected struct {
+		val []uint64
+	}
+
+	var tests = []struct {
+		name     string
+		precond  precond
+		args     args
+		expected expected
+	}{
+		{
+			name: "env not set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: false,
+					val:   "1,27",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+		{
+			name: "env set - env value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []uint64{1, 2},
+			},
+		},
+		{
+			name: "env set, no separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        "",
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+		{
+			name: "env set, wrong separator - default value returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "1,2",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+				sep:        "|",
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+		{
+			name: "empty env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []uint64{99},
+			},
+			expected: expected{
+				val: []uint64{99},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.precond.maybeSetEnv(t, tt.args.key)
+
+			got := uint64SliceOrDefault(tt.args.key, tt.args.defaultVal, tt.args.sep)
+			assert.Equal(t, tt.expected.val, got)
+		})
+	}
+}

--- a/internal/parsers_test.go
+++ b/internal/parsers_test.go
@@ -7,23 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testEnvKey = "GH_GETENV_TEST"
-
-type setenv struct {
-	isSet bool
-	val   string
-}
-
-type precond struct {
-	setenv setenv
-}
-
-func (p precond) maybeSetEnv(tb testing.TB, key string) {
-	if p.setenv.isSet {
-		tb.Setenv(key, p.setenv.val)
-	}
-}
-
 func Benchmark_float64SliceOrDefault(b *testing.B) {
 	p := precond{
 		setenv: setenv{
@@ -39,33 +22,6 @@ func Benchmark_float64SliceOrDefault(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_ = float64SliceOrDefault(testEnvKey, []float64{}, ",")
-	}
-}
-
-func TestNewEnvParser(t *testing.T) {
-	type args struct {
-		v any
-	}
-	
-	tests := []struct {
-		name string
-		args args
-		want EnvParser
-	}{
-		{
-			name: "",
-			args: args{
-				v: int64(0),
-			},
-			want: int64Parser(0),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NewEnvParser(tt.args.v)
-			assert.Equal(t, tt.want, got)
-		})
 	}
 }
 
@@ -738,6 +694,24 @@ func Test_float64SliceOrDefault(t *testing.T) {
 			args: args{
 				key:        testEnvKey,
 				defaultVal: []float64{-99.99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []float64{-99.99},
+			},
+		},
+		{
+			name: "malformed data value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "sss,sss",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []float64{-99.99},
+				sep:        ",",
 			},
 			expected: expected{
 				val: []float64{-99.99},
@@ -856,6 +830,23 @@ func Test_int64SliceOrDefault(t *testing.T) {
 				val: []int64{-99},
 			},
 		},
+		{
+			name: "malformed env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "sssss,999",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: []int64{-99},
+				sep:        ",",
+			},
+			expected: expected{
+				val: []int64{-99},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -927,6 +918,23 @@ func Test_timeOrDefault(t *testing.T) {
 				setenv: setenv{
 					isSet: true,
 					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Date(2021, 04, 21, 22, 30, 0, 0, time.UTC),
+				layout:     layout,
+			},
+			expected: expected{
+				val: time.Date(2021, 04, 21, 22, 30, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "malformed env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "20222-sdslll",
 				},
 			},
 			args: args{
@@ -1014,6 +1022,22 @@ func Test_durationOrDefault(t *testing.T) {
 				val: time.Second * 42,
 			},
 		},
+		{
+			name: "malformed env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "yyydd88",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: time.Second * 42,
+			},
+			expected: expected{
+				val: time.Second * 42,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1080,6 +1104,22 @@ func Test_uint64OrDefault(t *testing.T) {
 				setenv: setenv{
 					isSet: true,
 					val:   "",
+				},
+			},
+			args: args{
+				key:        testEnvKey,
+				defaultVal: 999,
+			},
+			expected: expected{
+				val: 999,
+			},
+		},
+		{
+			name: "malformed env value set - default returned",
+			precond: precond{
+				setenv: setenv{
+					isSet: true,
+					val:   "iii99",
 				},
 			},
 			args: args{

--- a/internal/parsers_test.go
+++ b/internal/parsers_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Benchmark_float64SliceOrDefault(b *testing.B) {
-	p := precond{
+	p := precondition{
 		setenv: setenv{
 			isSet: true,
 			val:   "1235.67,87.98",
@@ -37,13 +37,13 @@ func Test_intOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "128",
@@ -59,7 +59,7 @@ func Test_intOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128",
@@ -75,7 +75,7 @@ func Test_intOrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -113,13 +113,13 @@ func Test_stringOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "newval",
@@ -135,7 +135,7 @@ func Test_stringOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "newval",
@@ -173,13 +173,13 @@ func Test_int64OrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "newval",
@@ -195,7 +195,7 @@ func Test_int64OrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1024",
@@ -211,7 +211,7 @@ func Test_int64OrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -249,13 +249,13 @@ func Test_float64OrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "newval",
@@ -271,7 +271,7 @@ func Test_float64OrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1024.123",
@@ -287,7 +287,7 @@ func Test_float64OrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -325,13 +325,13 @@ func Test_boolOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "true",
@@ -347,7 +347,7 @@ func Test_boolOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "true",
@@ -363,7 +363,7 @@ func Test_boolOrDefault(t *testing.T) {
 		},
 		{
 			name: "invalid env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "128s7",
@@ -402,13 +402,13 @@ func Test_stringSliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "true,newval",
@@ -425,7 +425,7 @@ func Test_stringSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "true,newval",
@@ -442,7 +442,7 @@ func Test_stringSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "true,newval",
@@ -459,7 +459,7 @@ func Test_stringSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -498,13 +498,13 @@ func Test_intSliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1,2",
@@ -521,7 +521,7 @@ func Test_intSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -538,7 +538,7 @@ func Test_intSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -555,7 +555,7 @@ func Test_intSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -572,7 +572,7 @@ func Test_intSliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -611,13 +611,13 @@ func Test_float64SliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1.05,2.07",
@@ -634,7 +634,7 @@ func Test_float64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1.05,2.07",
@@ -651,7 +651,7 @@ func Test_float64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1.05,2.07",
@@ -668,7 +668,7 @@ func Test_float64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1.05,2.07",
@@ -685,7 +685,7 @@ func Test_float64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -702,7 +702,7 @@ func Test_float64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "malformed data value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "sss,sss",
@@ -742,13 +742,13 @@ func Test_int64SliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1.05,2.07",
@@ -765,7 +765,7 @@ func Test_int64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -782,7 +782,7 @@ func Test_int64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -799,7 +799,7 @@ func Test_int64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -816,7 +816,7 @@ func Test_int64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -832,7 +832,7 @@ func Test_int64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "malformed env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "sssss,999",
@@ -874,13 +874,13 @@ func Test_timeOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "2018/21/04 22:30",
@@ -897,7 +897,7 @@ func Test_timeOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "2018/21/04 22:30",
@@ -914,7 +914,7 @@ func Test_timeOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -931,7 +931,7 @@ func Test_timeOrDefault(t *testing.T) {
 		},
 		{
 			name: "malformed env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "20222-sdslll",
@@ -970,13 +970,13 @@ func Test_durationOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "12s",
@@ -992,7 +992,7 @@ func Test_durationOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12s",
@@ -1008,7 +1008,7 @@ func Test_durationOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -1024,7 +1024,7 @@ func Test_durationOrDefault(t *testing.T) {
 		},
 		{
 			name: "malformed env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "yyydd88",
@@ -1062,13 +1062,13 @@ func Test_uint64OrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "12",
@@ -1084,7 +1084,7 @@ func Test_uint64OrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "12",
@@ -1100,7 +1100,7 @@ func Test_uint64OrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",
@@ -1116,7 +1116,7 @@ func Test_uint64OrDefault(t *testing.T) {
 		},
 		{
 			name: "malformed env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "iii99",
@@ -1155,13 +1155,13 @@ func Test_uint64SliceOrDefault(t *testing.T) {
 
 	var tests = []struct {
 		name     string
-		precond  precond
+		precond  precondition
 		args     args
 		expected expected
 	}{
 		{
 			name: "env not set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: false,
 					val:   "1,27",
@@ -1178,7 +1178,7 @@ func Test_uint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set - env value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -1195,7 +1195,7 @@ func Test_uint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, no separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -1212,7 +1212,7 @@ func Test_uint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "env set, wrong separator - default value returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "1,2",
@@ -1229,7 +1229,7 @@ func Test_uint64SliceOrDefault(t *testing.T) {
 		},
 		{
 			name: "empty env value set - default returned",
-			precond: precond{
+			precond: precondition{
 				setenv: setenv{
 					isSet: true,
 					val:   "",

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -1,0 +1,38 @@
+package option
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/obalunenko/getenv/internal"
+)
+
+func TestOptions(t *testing.T) {
+	var p internal.Parameters
+
+	var opt Option
+
+	opt = WithSeparator("|")
+
+	opt.Apply(&p)
+
+	expected := internal.Parameters{
+		Separator: "|",
+		Layout:    "",
+	}
+
+	assert.Equal(t, expected, p)
+
+	opt = WithTimeLayout(time.RFC822)
+
+	opt.Apply(&p)
+
+	expected = internal.Parameters{
+		Separator: "|",
+		Layout:    time.RFC822,
+	}
+
+	assert.Equal(t, expected, p)
+}

--- a/scripts/tests/run.sh
+++ b/scripts/tests/run.sh
@@ -8,7 +8,7 @@ echo "${SCRIPT_NAME} is running... "
 
 GOTEST="go test -v "
 if command -v "gotestsum" &>/dev/null; then
-  GOTEST="gotestsum --format pkgname-and-test-fails --"
+  GOTEST="gotestsum --format testname --"
 fi
 
 ${GOTEST} -race ./...


### PR DESCRIPTION
## Description

- Implement parsers for uint64 and []uint64
- Removed deprecated API functions
- 100% tests coverage

## Possible failures/side-effects

Compiler errors when users upgrade to this version if they not migrated from deprecated functions to EnvOrDefault usage

## Other notes

none
